### PR TITLE
fix: correct daily average calculation (fixes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Time Tracker
 
-[![Version](https://img.shields.io/badge/version-0.8.7-blue.svg)](https://github.com/AhogeK/code-time-tracker)
+[![Version](https://img.shields.io/badge/version-0.8.8-blue.svg)](https://github.com/AhogeK/code-time-tracker)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-IntelliJ%202025.3%2B-orange.svg)](https://plugins.jetbrains.com/)
 
@@ -8,7 +8,7 @@ A JetBrains Platform plugin for automatic coding time tracking and analytics.
 
 ## 📋 Requirements
 
-- **JetBrains IDEs 2025.1** or later (Build 251+)
+- **JetBrains IDEs 2025.3** or later (Build 253+)
   *(Compatible with IntelliJ IDEA, PyCharm, WebStorm, GoLand, Android Studio, etc.)*
 - **Java 21** runtime (Bundled with IDE 2025.1+)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 
 # Plugin versioning
-pluginVersion = "0.8.7"
+pluginVersion = "0.8.8"
 
 # dependencies versions
 junitVersion = "6.0.1"
-assertjCoreVersion = "3.27.6"
+assertjCoreVersion = "4.0.0-M1"
 sqliteJdbcVersion = "3.51.1.0"
 gsonVersion = "2.13.2"
 lGoodDatePickerVersion = "11.2.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/ahogek/codetimetracker/statistics/SummaryDataProvider.kt
+++ b/src/main/kotlin/com/ahogek/codetimetracker/statistics/SummaryDataProvider.kt
@@ -137,7 +137,7 @@ class SummaryDataProvider : ChartDataProvider {
 
         // Calculate daily average
         val dailyAverage = if (firstDate != null) {
-            val daysSinceFirst = ChronoUnit.DAYS.between(firstDate, today).coerceAtLeast(1)
+            val daysSinceFirst = ChronoUnit.DAYS.between(firstDate, today).plus(1).coerceAtLeast(1)
             Duration.ofSeconds(totalDuration.toSeconds() / daysSinceFirst)
         } else {
             Duration.ZERO
@@ -251,7 +251,7 @@ class SummaryDataProvider : ChartDataProvider {
         val firstRecordDate = DatabaseManager.getFirstRecordDate()
 
         val dailyAverage = if (firstRecordDate != null) {
-            val daysSinceFirst = ChronoUnit.DAYS.between(firstRecordDate, today).coerceAtLeast(1)
+            val daysSinceFirst = ChronoUnit.DAYS.between(firstRecordDate, today).plus(1).coerceAtLeast(1)
             Duration.ofSeconds(totalDuration.toSeconds() / daysSinceFirst)
         } else {
             Duration.ZERO

--- a/src/test/kotlin/com/ahogek/codetimetracker/statistics/SummaryDataProviderTest.kt
+++ b/src/test/kotlin/com/ahogek/codetimetracker/statistics/SummaryDataProviderTest.kt
@@ -1,0 +1,51 @@
+package com.ahogek.codetimetracker.statistics
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+class SummaryDataProviderTest {
+
+    @Test
+    fun testDailyAverageCalculationIncludesBothStartAndEndDays() {
+        val firstDate = LocalDate.of(2026, 2, 15)
+        val today = LocalDate.of(2026, 2, 16)
+
+        val daysSinceFirst = ChronoUnit.DAYS.between(firstDate, today).plus(1).coerceAtLeast(1)
+
+        assertEquals(2, daysSinceFirst, "Should be 2 days (Feb 15 and Feb 16)")
+    }
+
+    @Test
+    fun testDailyAverageCalculationWithMultipleDays() {
+        val firstDate = LocalDate.of(2026, 2, 1)
+        val today = LocalDate.of(2026, 2, 16)
+
+        val daysSinceFirst = ChronoUnit.DAYS.between(firstDate, today).plus(1).coerceAtLeast(1)
+
+        assertEquals(16, daysSinceFirst, "Should be 16 days (Feb 1 to Feb 16 inclusive)")
+    }
+
+    @Test
+    fun testDailyAverageCalculationSameDay() {
+        val firstDate = LocalDate.of(2026, 2, 16)
+        val today = LocalDate.of(2026, 2, 16)
+
+        val daysSinceFirst = ChronoUnit.DAYS.between(firstDate, today).plus(1).coerceAtLeast(1)
+
+        assertEquals(1, daysSinceFirst, "Should be 1 day when first date equals today")
+    }
+
+    @Test
+    fun testDailyAverageWithDuration() {
+        val firstDate = LocalDate.of(2026, 2, 15)
+        val today = LocalDate.of(2026, 2, 16)
+        val totalSeconds = 16 * 60 * 60L
+
+        val daysSinceFirst = ChronoUnit.DAYS.between(firstDate, today).plus(1).coerceAtLeast(1)
+        val dailyAverageSeconds = totalSeconds / daysSinceFirst
+
+        assertEquals(8 * 60 * 60L, dailyAverageSeconds, "16 hours / 2 days = 8 hours")
+    }
+}


### PR DESCRIPTION
## Summary
- Fix daily average calculation to correctly divide by the number of days including both start and end dates
- Add `.plus(1)` to `ChronoUnit.DAYS.between()` in both `computeSummaryInMemory()` and `computeSummaryWithSQL()` methods
- Update version to 0.8.8 and README to reflect 2025.3 platform requirement
- Add unit tests for daily average calculation

## Fixes
Fixes #2